### PR TITLE
Impletement Rest Template client to fetch all categories from Fake Store

### DIFF
--- a/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategoryGateway.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategoryGateway.java
@@ -3,12 +3,13 @@ package com.example.Ecommerce.gateway;
 import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
 import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCategoryResponse;
 import com.example.Ecommerce.gateway.api.FakeStoreCategoryApi;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.List;
 
-@Component
+@Component("fakeStoreCategoryGateway")
 public class FakeStoreCategoryGateway implements ICategoryGateway{
     private final FakeStoreCategoryApi fakeStoreCategoryApi;
 

--- a/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategory_RestTemplate.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategory_RestTemplate.java
@@ -1,0 +1,39 @@
+package com.example.Ecommerce.gateway;
+
+import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
+import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCategoryResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+import java.io.IOException;
+import java.util.List;
+
+@Component("fakeStoreCategory_RestTemplate")
+public class FakeStoreCategory_RestTemplate implements ICategoryGateway{
+
+    @Autowired
+    private Environment environment;
+
+    private final RestTemplateBuilder restTemplateBuilder;
+    private FakeStoreCategory_RestTemplate(RestTemplateBuilder restTemplateBuilder){
+        this.restTemplateBuilder = restTemplateBuilder;
+    }
+    @Override
+    public List<CategoryDTO> getAllCategories() throws IOException {
+        String url = environment.getProperty("BASE_URL") +"products/category";
+        ResponseEntity<FakeStoreCategoryResponse> response=restTemplateBuilder.build().getForEntity(url, FakeStoreCategoryResponse.class);
+        if(response.getBody() == null){
+            throw new IOException("Response is empty");
+        }
+        return response.getBody().getCategories().stream()
+                .map( category -> CategoryDTO.builder()
+                        .name(category)
+                        .build()).toList();
+    }
+}

--- a/Ecommerce/src/main/java/com/example/Ecommerce/services/FakeStoreCategoryService.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/services/FakeStoreCategoryService.java
@@ -2,6 +2,7 @@ package com.example.Ecommerce.services;
 
 import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
 import com.example.Ecommerce.gateway.ICategoryGateway;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -11,7 +12,7 @@ import java.util.List;
 public class FakeStoreCategoryService implements ICategoryService{
     private final ICategoryGateway categoryGateway;
 
-    public FakeStoreCategoryService(ICategoryGateway categoryGateway) {
+    public FakeStoreCategoryService(@Qualifier("fakeStoreCategory_RestTemplate") ICategoryGateway categoryGateway) {
         this.categoryGateway = categoryGateway;
     }
 


### PR DESCRIPTION
**Description:**
This PR introduces a new RestTemplate-based client to fetch the list of product categories from the Fake Store API.

Changes Made:

- Added RestTemplate bean configuration (if not already present).
- Created a service/component class to call the /products/categories endpoint.
- Parsed and returned the category data as a list of CategoryDTO.

Why:
To integrate Fake Store API data into our application and enable category-driven functionality.

Test Coverage:
✅ Successfully fetched data from the API
✅ Handles empty or error responses gracefully