### PR TITLE
Implemented Mapper class to achieve Readability and SRP

### DIFF
--- a/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategoryGateway.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategoryGateway.java
@@ -3,7 +3,7 @@ package com.example.Ecommerce.gateway;
 import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
 import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCategoryResponse;
 import com.example.Ecommerce.gateway.api.FakeStoreCategoryApi;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.example.Ecommerce.mapper.CategoryMapper;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -20,10 +20,9 @@ public class FakeStoreCategoryGateway implements ICategoryGateway{
     @Override
     public List<CategoryDTO> getAllCategories() throws IOException {
         FakeStoreCategoryResponse response = this.fakeStoreCategoryApi.getAllFakeStoreCategories().execute().body();
-
-        return response.getCategories().stream()
-                .map( category -> CategoryDTO.builder()
-                        .name(category)
-                        .build()).toList();
+        if(response == null){
+           throw new IOException("Response is empty!!");
+        }
+        return CategoryMapper.toCategoryDTOList(response);
     }
 }

--- a/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategory_RestTemplate.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreCategory_RestTemplate.java
@@ -2,13 +2,12 @@ package com.example.Ecommerce.gateway;
 
 import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
 import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCategoryResponse;
+import com.example.Ecommerce.mapper.CategoryMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 
 
 import java.io.IOException;
@@ -31,9 +30,6 @@ public class FakeStoreCategory_RestTemplate implements ICategoryGateway{
         if(response.getBody() == null){
             throw new IOException("Response is empty");
         }
-        return response.getBody().getCategories().stream()
-                .map( category -> CategoryDTO.builder()
-                        .name(category)
-                        .build()).toList();
+        return CategoryMapper.toCategoryDTOList(response.getBody());
     }
 }

--- a/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreProductGateway.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/gateway/FakeStoreProductGateway.java
@@ -7,6 +7,7 @@ import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCreateProductRespo
 import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreProductByIdResponse;
 import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreProductsByCategoryResponse;
 import com.example.Ecommerce.gateway.api.FakeStoreProductApi;
+import com.example.Ecommerce.mapper.ProductMapper;
 import org.springframework.stereotype.Component;
 import retrofit2.Response;
 
@@ -24,36 +25,21 @@ public class FakeStoreProductGateway implements IProductGateway {
     @Override
     public List<ProductDTO> getProductsByCategory(String type) throws IOException {
         FakeStoreProductsByCategoryResponse response = fakeStoreProductApi.getProductsByCategory(type).execute().body();
-        return response.getProducts().stream()
-                .map( product -> ProductDTO.builder()
-                        .price(product.getPrice())
-                        .title(product.getTitle())
-                        .brand(product.getBrand())
-                        .model(product.getModel()).build()
-                ).toList();
+        return ProductMapper.toProductDTOList(response);
     }
 
     @Override
     public ProductDTO getProductById(Long Id) throws IOException {
         FakeStoreProductByIdResponse response = fakeStoreProductApi.getProductById(Id).execute().body();
-
-        return ProductDTO.builder()
-                .title(response.getProduct().getTitle())
-                .price(response.getProduct().getPrice())
-                .brand(response.getProduct().getBrand())
-                .model(response.getProduct().getModel()).build();
+        return ProductMapper.toProductDTO(response);
     }
 
     @Override
     public CreateProductResponse createProduct(CreateProductRequest productRequest) throws IOException {
 
         Response<FakeStoreCreateProductResponse> response = fakeStoreProductApi.createProduct(productRequest).execute();
-
         if(response.isSuccessful() ){
-            return CreateProductResponse.builder()
-                    .product(response.body().getProduct())
-                    .status(response.body().getStatus())
-                    .message(response.body().getMessage()).build();
+            return ProductMapper.toCreateProductResponse(response.body());
         }
         else {
             System.out.println("API Error: " + response.errorBody().string());

--- a/Ecommerce/src/main/java/com/example/Ecommerce/mapper/CategoryMapper.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/mapper/CategoryMapper.java
@@ -1,0 +1,18 @@
+package com.example.Ecommerce.mapper;
+
+import com.example.Ecommerce.dto.controllerDTO.Response.CategoryDTO;
+import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCategoryResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CategoryMapper {
+    public static List<CategoryDTO> toCategoryDTOList(FakeStoreCategoryResponse fakeStoreCategoryResponse){
+        return fakeStoreCategoryResponse.getCategories().stream()
+                .map(e ->CategoryDTO.builder()
+                        .name(e)
+                        .build()
+                ).toList();
+    }
+}

--- a/Ecommerce/src/main/java/com/example/Ecommerce/mapper/ProductMapper.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/mapper/ProductMapper.java
@@ -1,0 +1,39 @@
+package com.example.Ecommerce.mapper;
+
+import com.example.Ecommerce.dto.controllerDTO.Response.CreateProductResponse;
+import com.example.Ecommerce.dto.controllerDTO.Response.ProductDTO;
+import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreCreateProductResponse;
+import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreProductByIdResponse;
+import com.example.Ecommerce.dto.gatewayDTO.Response.FakeStoreProductsByCategoryResponse;
+
+import java.util.List;
+
+public class ProductMapper {
+
+    public static CreateProductResponse toCreateProductResponse(FakeStoreCreateProductResponse fakeStoreCreateProductResponse){
+        return CreateProductResponse.builder()
+                .product(fakeStoreCreateProductResponse.getProduct())
+                .message(fakeStoreCreateProductResponse.getStatus())
+                .status(fakeStoreCreateProductResponse.getMessage()).build();
+    }
+
+    public static ProductDTO toProductDTO(FakeStoreProductByIdResponse response){
+        return ProductDTO.builder()
+                .brand(response.getProduct().getBrand())
+                .model(response.getProduct().getModel())
+                .price(response.getProduct().getPrice())
+                .title(response.getProduct().getTitle())
+                .build();
+    }
+
+    public static List<ProductDTO> toProductDTOList(FakeStoreProductsByCategoryResponse response){
+        return response.getProducts().stream().map(e ->
+                ProductDTO.builder()
+                        .title(e.getTitle())
+                        .price(e.getPrice())
+                        .model(e.getModel())
+                        .brand(e.getBrand())
+                        .build()
+                ).toList();
+    }
+}


### PR DESCRIPTION
**This PR introduces dedicated mapper classes for Category and Product to transform API responses into domain models. This improves code readability and ensures adherence to the Single Responsibility Principle (SRP).**

Key Changes:

- Added CategoryMapper to handle mapping of category-related data
- Added ProductMapper to handle mapping of product-related data
- Refactored existing logic to delegate transformation responsibilities to the mappers
- Improved code organization and separation of concerns

Why:
To isolate mapping logic from service layers, improve maintainability, and follow clean architecture practices.