### PR TITLE
Implemented product details with category details in product controller

### DIFF
--- a/Ecommerce/src/main/java/com/example/Ecommerce/controllers/ProductController.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/controllers/ProductController.java
@@ -1,5 +1,6 @@
 package com.example.Ecommerce.controllers;
 
+import com.example.Ecommerce.dto.ProductWithCategoryDTO;
 import com.example.Ecommerce.dto.controllerDTO.Response.CreateProductResponse;
 import com.example.Ecommerce.dto.ProductDTO;
 import com.example.Ecommerce.dto.controllerDTO.Resquest.CreateProductRequest;
@@ -32,6 +33,11 @@ public class ProductController {
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CreateProductResponse> createProduct(@RequestBody CreateProductRequest product) {
         CreateProductResponse response = productService.createProduct(product);
+        return ResponseEntity.ok(response);
+    }
+    @GetMapping("/{id}/category")
+    public ResponseEntity<ProductWithCategoryDTO> getProductWithCategory(@PathVariable("id") Long id){
+        ProductWithCategoryDTO response = productService.getProductWithCategory(id);
         return ResponseEntity.ok(response);
     }
 }

--- a/Ecommerce/src/main/java/com/example/Ecommerce/dto/ProductWithCategoryDTO.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/dto/ProductWithCategoryDTO.java
@@ -1,0 +1,20 @@
+package com.example.Ecommerce.dto;
+
+import com.example.Ecommerce.dto.controllerDTO.Response.CategoryResponseDTO;
+import lombok.Builder;
+
+@Builder
+public class ProductWithCategoryDTO {
+    private Long id ;
+    private String title ;
+    private String image ;
+    private double price ;
+    private String description ;
+    private String brand ;
+    private String model ;
+    private String color ;
+    private Long category_id ;
+    private boolean popular ;
+    private int discount ;
+    private CategoryResponseDTO category;
+}

--- a/Ecommerce/src/main/java/com/example/Ecommerce/services/IProductService.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/services/IProductService.java
@@ -1,6 +1,7 @@
 package com.example.Ecommerce.services;
 
 import com.example.Ecommerce.dto.ProductDTO;
+import com.example.Ecommerce.dto.ProductWithCategoryDTO;
 import com.example.Ecommerce.dto.controllerDTO.Response.CreateProductResponse;
 
 import com.example.Ecommerce.dto.controllerDTO.Resquest.CreateProductRequest;
@@ -13,4 +14,5 @@ public interface IProductService {
     List<ProductDTO> getProductByCategory(String type) ;
     ProductDTO getProductById(Long Id) ;
     CreateProductResponse createProduct(CreateProductRequest product) ;
+    ProductWithCategoryDTO getProductWithCategory(Long id) ;
 }

--- a/Ecommerce/src/main/java/com/example/Ecommerce/services/ProductService.java
+++ b/Ecommerce/src/main/java/com/example/Ecommerce/services/ProductService.java
@@ -1,5 +1,6 @@
 package com.example.Ecommerce.services;
 
+import com.example.Ecommerce.dto.ProductWithCategoryDTO;
 import com.example.Ecommerce.dto.controllerDTO.Response.CategoryResponseDTO;
 import com.example.Ecommerce.dto.controllerDTO.Response.CreateProductResponse;
 import com.example.Ecommerce.dto.ProductDTO;
@@ -91,5 +92,10 @@ public class ProductService implements IProductService {
                     .message("An unexpected error occurred: " + ex.getMessage())
                     .build();
         }
+    }
+
+    @Override
+    public ProductWithCategoryDTO getProductWithCategory(Long id) {
+        return null;
     }
 }


### PR DESCRIPTION
**This PR enhances the ProductController by including category details in the product details response. This allows clients to receive both product and related category information in a single API call.**

**Changes Made:**

- Modified the ProductController to fetch and return category details alongside product data.
- Adjusted the response structure (e.g., DTO/serializer) to include category fields.
- No service layer is implemented at this stage

**Impact:**

- Enables API consumers to access category information with product data.

Current implementation is controller-centric and may be refactored later once the service layer is introduced.